### PR TITLE
Provide our own firewall::allow type

### DIFF
--- a/dist/profile/manifests/firewall/allow.pp
+++ b/dist/profile/manifests/firewall/allow.pp
@@ -1,0 +1,23 @@
+define profile::firewall::allow(
+  Variant[String[1], Integer] $port,
+  Enum[tcp, udp] $proto = 'tcp',
+  Any $from = 'any',
+  Any $ensure = 'present',
+) {
+
+  ::ufw::allow { "${title}-v4":
+    ensure => $ensure,
+    proto  => $proto,
+    port   => $port,
+    ip     => $::facts['networking']['interfaces']['eth0']['ip'],
+    from   => $from,
+  }
+
+  ::ufw::allow { "${title}-v6":
+    ensure => $ensure,
+    proto  => $proto,
+    port   => $port,
+    ip     => $::facts['networking']['interfaces']['eth0']['ip6'],
+    from   => $from,
+  }
+}

--- a/dist/profile/manifests/monitoring.pp
+++ b/dist/profile/manifests/monitoring.pp
@@ -17,7 +17,7 @@ class profile::monitoring {
     interval => hiera('collectd::plugin::ping::interval'),
   }
 
-  ::ufw::allow { 'allow-world-facette':
+  ::profile::firewall::allow { 'allow-world-facette':
     port => 12003,
   }
 }

--- a/dist/profile/manifests/pupa/packages.pp
+++ b/dist/profile/manifests/pupa/packages.pp
@@ -17,7 +17,7 @@ class profile::pupa::packages {
     require => Apt::Source['mosh'],
   }
 
-  ::ufw::allow { 'allow-world-mosh':
+  ::profile::firewall::allow { 'allow-world-mosh':
     port  => '60000:61000',
     proto => 'udp',
   }
@@ -32,7 +32,7 @@ class profile::pupa::packages {
     require => Apt::Source['znc'],
   }
 
-  ::ufw::allow { 'allow-world-znc':
+  ::profile::firewall::allow { 'allow-world-znc':
     port => 6697,
   }
 }

--- a/dist/profile/manifests/ssh.pp
+++ b/dist/profile/manifests/ssh.pp
@@ -10,7 +10,7 @@ class profile::ssh {
     notify  => Class['::ssh::server::service'],
   }
 
-  ::ufw::allow { 'allow-world-ssh':
+  ::profile::firewall::allow { 'allow-world-ssh':
     port => 22,
   }
 }

--- a/dist/profile/spec/classes/monitoring_spec.rb
+++ b/dist/profile/spec/classes/monitoring_spec.rb
@@ -4,10 +4,15 @@ describe 'profile::monitoring' do
   let(:pre_condition) {
     'include apt'
   }
-  let(:facts) { {:osfamily => 'Debian',
-                 :concat_basedir => '/tmp',
-                 :lsbdistcodename => 'trusty',
-                 :lsbdistid => 'Ubuntu' } }
+  let(:facts) { {
+    :osfamily => 'Debian',
+    :concat_basedir => '/tmp',
+    :lsbdistcodename => 'trusty',
+    :lsbdistid => 'Ubuntu',
+    :networking => { :interfaces => { :eth0 => { :ip => '127.0.0.1',
+                                                 :ip6 => '::1',}}},
+  }}
+
   it { is_expected.to contain_class('collectd') }
   it { is_expected.to contain_class('facette') }
 
@@ -26,7 +31,7 @@ describe 'profile::monitoring' do
     :interval => 5,
   })}
 
-  it { is_expected.to contain_ufw__allow('allow-world-facette').with({
+  it { is_expected.to contain_profile__firewall__allow('allow-world-facette').with({
     :port => 12003,
   })}
 end

--- a/dist/profile/spec/classes/pupa/packages_spec.rb
+++ b/dist/profile/spec/classes/pupa/packages_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'profile::pupa::packages' do
+  let(:facts) {{
+    :networking => { :interfaces => { :eth0 => { :ip => '127.0.0.1',
+                                                 :ip6 => '::1',}}},
+  }}
   it { is_expected.to contain_package('fish').with({
     :ensure  => 'latest',
     :require => 'Apt::Source[fish]',

--- a/dist/profile/spec/classes/ssh_spec.rb
+++ b/dist/profile/spec/classes/ssh_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe 'profile::ssh' do
-  let(:facts) { {:osfamily => 'Debian', :concat_basedir => '/tmp' } }
+  let(:facts) { {
+    :osfamily => 'Debian',
+    :concat_basedir => '/tmp',
+    :networking => { :interfaces => { :eth0 => { :ip => '127.0.0.1',
+                                                 :ip6 => '::1',}}},
+  }}
   it { is_expected.to contain_class('ssh') }
   it { is_expected.to contain_file('/etc/ssh/moduli').with({
     :ensure => 'file',
@@ -11,7 +16,7 @@ describe 'profile::ssh' do
     :content => 'potato ba-boy',
     :notify  => 'Class[Ssh::Server::Service]',
   })}
-  it { is_expected.to contain_ufw__allow('allow-world-ssh').with({
+  it { is_expected.to contain_profile__firewall__allow('allow-world-ssh').with({
     :port => 22,
   })}
 end


### PR DESCRIPTION
This makes us no longer directly depend on ufw and evolve the API as wesee fit. Additionally it now generates v6 rules too.
